### PR TITLE
subprojects: pin subproject dependencies git revisions

### DIFF
--- a/subprojects/argp.wrap
+++ b/subprojects/argp.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/argp-standalone/argp-standalone
-revision = head
+revision = 8ded2bc942740b5d291e450af661c5090dc3ca38
 directory = libargp
 patch_directory = libargp

--- a/subprojects/disarm.wrap
+++ b/subprojects/disarm.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/aengelke/disarm.git
-revision = master
+revision = 2d13d3f410a52daff1c5d8ef07d623332f372560
 directory = disarm
 patch_directory = disarm

--- a/subprojects/fadec.wrap
+++ b/subprojects/fadec.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/aengelke/fadec.git
-revision = master
+revision = c0139efde553cabff74d161fde77280890d2679a
 directory = fadec
 patch_directory = fadec


### PR DESCRIPTION
This allows building LFI in sandboxed environments like Nix, and
provides assurance that a specific LFI revision will not silently
break or diverge due to updates of its underlying dependencies.
