### PR TITLE
subprojects/argp: remove patch_directory attribute

### DIFF
--- a/subprojects/argp.wrap
+++ b/subprojects/argp.wrap
@@ -2,4 +2,3 @@
 url = https://github.com/argp-standalone/argp-standalone
 revision = 8ded2bc942740b5d291e450af661c5090dc3ca38
 directory = libargp
-patch_directory = libargp


### PR DESCRIPTION
When this directory is specified but does not exist, fetching subprojects fails with the following error:

    =====> Fetching ./subprojects/argp.wrap, placed in libargp
    Cloning into 'libargp'...
    remote: Enumerating objects: 361, done.
    remote: Counting objects: 100% (123/123), done.
    remote: Compressing objects: 100% (49/49), done.
    remote: Total 361 (delta 96), reused 75 (delta 73), pack-reused 238 (from 1)
    Receiving objects: 100% (361/361), 283.92 KiB | 7.89 MiB/s, done.
    Resolving deltas: 100% (216/216), done.
    HEAD is now at 8ded2bc infer library versions from project version (#25)
    Download argp...
      -> patch directory does not exist: libargp
